### PR TITLE
Delete the copy related constructors and adapt nfds for linux

### DIFF
--- a/kissnet.cpp
+++ b/kissnet.cpp
@@ -22,3 +22,4 @@ std::map<SOCKET, kissnet::tcp_ssl_socket*> KISSNET_API kissnet::tcp_ssl_socket::
 template<>
 std::map<SOCKET, kissnet::udp_socket*> KISSNET_API kissnet::udp_socket::sockets {};
 
+fd_set kissnet::FdSets::mFdSetNull;

--- a/kissnet.hpp
+++ b/kissnet.hpp
@@ -1526,7 +1526,7 @@ namespace kissnet
 		int mHighestFd;
 		#endif
 
-	public :
+	public:
 	
 		fd_set& operator[](FdSetType setType)
 		{
@@ -1551,7 +1551,7 @@ namespace kissnet
 			nfds = nfds > mFdSets[FdSetType::except].fd_count ? nfds : 
 				mFdSets[FdSetType::except].fd_count;
 			#else
-				nfds = mHighestFd;
+				nfds = mHighestFd + 1;
 			#endif
 
 			return nfds;
@@ -1682,6 +1682,9 @@ namespace kissnet
 		{
 			FD_CLR(fd, &mFdSets[setType]);
 		}
+
+
+		friend class MultiSocketSelector;
 	};
 
 	/**
@@ -1767,7 +1770,9 @@ namespace kissnet
 		 */
 		socket_status select(int64_t timeout, FdSets& fdSetsResult)
 		{
-			fdSetsResult = mFdSets;
+			fdSetsResult[FdSetType::read] = mFdSets[FdSetType::read];
+			fdSetsResult[FdSetType::write] = mFdSets[FdSetType::write];
+			fdSetsResult[FdSetType::except] = mFdSets[FdSetType::except];
 
 			struct timeval tv;
 


### PR DESCRIPTION
Deleted copy and copy assignment operator of MultiSocketSelecter which were source of causes for singleton desing. MultiSocketSelecter is designed to have only one instance which is accessable from everywhere.

Also fixed the problem of fd_count field not available on the fd_set struct for linux. 